### PR TITLE
Add error responses to AccessToken.fetch

### DIFF
--- a/lib/pxu_auth0.ex
+++ b/lib/pxu_auth0.ex
@@ -1,5 +1,19 @@
 defmodule PxUAuth0 do
-  @moduledoc """
-  Documentation for PxUAuth0.
-  """
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    # List all child processes to be supervised
+    children = [
+      # Starts a worker by calling: PxUAuth0.Worker.start_link(arg)
+      # {PxUAuth0.Worker, arg}
+      PxUAuth0.AccessToken
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: ExAuth0Client.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
 end

--- a/lib/pxu_auth0/access_token.ex
+++ b/lib/pxu_auth0/access_token.ex
@@ -17,13 +17,13 @@ defmodule PxUAuth0.AccessToken do
 
   ```
   iex(1)> PxUAuth0.AccessToken.start_link()
-  iex(2)> PxUAuth0.fetch
+  iex(2)> PxUAuth0.AccessToken.fetch
   {:ok, nkkdaknwpiepoqiwe....
   ```
   """
 
-  def start_link(initial_state \\ %{}) do
-    Agent.start_link(fn -> initial_state end, name: __MODULE__)
+  def start_link(_args) do
+    Agent.start_link(fn -> %{} end, name: __MODULE__)
   end
 
   @doc """

--- a/lib/pxu_auth0/access_token.ex
+++ b/lib/pxu_auth0/access_token.ex
@@ -82,6 +82,9 @@ defmodule PxUAuth0.AccessToken do
       {:ok, %{body: error}} ->
         {:error, error}
 
+      {:ok, %{body: {:error, %Jason.DecodeError{} = error}}} ->
+        {:error, error}
+
       {:error, error} ->
         {:error, error}
     end

--- a/lib/pxu_auth0/access_token.ex
+++ b/lib/pxu_auth0/access_token.ex
@@ -16,8 +16,8 @@ defmodule PxUAuth0.AccessToken do
   ## Usage
 
   ```
-  iex(1)> PxUAuth0.AccessToken.start_link()
-  iex(2)> PxUAuth0.AccessToken.fetch
+  $ iex -S mix
+  iex(1)> PxUAuth0.AccessToken.fetch
   {:ok, nkkdaknwpiepoqiwe....
   ```
   """
@@ -32,7 +32,7 @@ defmodule PxUAuth0.AccessToken do
   """
   def fetch do
     with nil <- get(),
-         :ok <- fetch_new_token() |> store do
+         :ok <- fetch_new_token() |> store() do
       fetch()
     else
       {:error, error} ->

--- a/lib/pxu_auth0/access_token.ex
+++ b/lib/pxu_auth0/access_token.ex
@@ -31,20 +31,23 @@ defmodule PxUAuth0.AccessToken do
   fetched from the Auth0 api.
   """
   def fetch do
-    case get() do
-      nil ->
-        Auth0API.create_token_request()
-        |> Auth0API.fetch_token()
-        |> store()
+    with nil <- get(),
+         :ok <- fetch_new_token() |> store do
+      fetch()
+    else
+      {:error, error} ->
+        {:error, error}
 
-        fetch()
-
-      token ->
-        token
+      access_token ->
+        {:ok, access_token}
     end
   end
 
-  def store(%{"access_token" => token}, date_time_impl \\ NaiveDateTime) do
+  def store(access_token, date_time_impl \\ NaiveDateTime)
+
+  def store({:error, _err} = error, _date_time_impl), do: error
+
+  def store(token, date_time_impl) do
     Agent.update(__MODULE__, fn state ->
       Map.merge(state, %{access_token: token, update_date: date_time_impl.utc_now()})
     end)
@@ -57,7 +60,7 @@ defmodule PxUAuth0.AccessToken do
            update_date
            |> NaiveDateTime.diff(NaiveDateTime.utc_now(), :millisecond)
            |> Kernel.<(expiry_time) do
-      {:ok, access_token}
+      access_token
     else
       _ ->
         nil
@@ -69,5 +72,18 @@ defmodule PxUAuth0.AccessToken do
   """
   def empty do
     Agent.update(__MODULE__, fn _state -> %{} end)
+  end
+
+  defp fetch_new_token do
+    case Auth0API.create_token_request() |> Auth0API.fetch_token() do
+      {:ok, %{body: %{"access_token" => token}}} ->
+        token
+
+      {:ok, %{body: error}} ->
+        {:error, error}
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 end

--- a/lib/pxu_auth0/auth0_api.ex
+++ b/lib/pxu_auth0/auth0_api.ex
@@ -12,9 +12,13 @@ defmodule PxUAuth0.Auth0API do
   def process_request_body(body), do: Jason.encode!(body)
 
   def process_response_body(body) do
-    {_status, result} = Jason.decode(body)
+    case Jason.decode(body) do
+      {:ok, body} ->
+        body
 
-    result
+      error ->
+        error
+    end
   end
 
   def create_token_request do

--- a/lib/pxu_auth0/auth0_api.ex
+++ b/lib/pxu_auth0/auth0_api.ex
@@ -11,7 +11,11 @@ defmodule PxUAuth0.Auth0API do
 
   def process_request_body(body), do: Jason.encode!(body)
 
-  def process_response_body(body), do: body |> Jason.decode!()
+  def process_response_body(body) do
+    {_status, result} = Jason.decode(body)
+
+    result
+  end
 
   def create_token_request do
     %{

--- a/lib/pxu_auth0/auth0_api.ex
+++ b/lib/pxu_auth0/auth0_api.ex
@@ -4,14 +4,14 @@ defmodule PxUAuth0.Auth0API do
 
   def fetch_token(request_body),
     do:
-      post!("https://#{config(:domain)}/oauth/token", request_body, [
+      post("https://#{config(:domain)}/oauth/token", request_body, [
         {"Accept", "application/json"},
         {"Content-Type", "application/json"}
       ])
 
   def process_request_body(body), do: Jason.encode!(body)
 
-  def process_response_body(body), do: body |> Jason.decode!() |> Map.get(:body, %{})
+  def process_response_body(body), do: body |> Jason.decode!()
 
   def create_token_request do
     %{

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule PxUAuth0.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {PxUAuth0, []}
     ]
   end
 

--- a/test/pxu_auth0/access_token_test.exs
+++ b/test/pxu_auth0/access_token_test.exs
@@ -10,7 +10,7 @@ defmodule PxUAuth0.AccessTokenTest do
   end
 
   setup do
-    AccessToken.start_link()
+    AccessToken.start_link(%{})
     :ok
   end
 

--- a/test/pxu_auth0/access_token_test.exs
+++ b/test/pxu_auth0/access_token_test.exs
@@ -17,13 +17,12 @@ defmodule PxUAuth0.AccessTokenTest do
   describe "get/0" do
     setup do
       AccessToken.empty()
-      %{token: %{"access_token" => %{"foo" => "bar"}}}
+      %{token: %{"foo" => "bar"}}
     end
 
     test "it looks up an access token if one exists", %{token: token} do
       AccessToken.store(token)
-      %{"access_token" => access_token} = token
-      assert AccessToken.get() == {:ok, access_token}
+      assert AccessToken.get() == token
     end
 
     test "it returns nil if date difference is greater than config", %{token: token} do


### PR DESCRIPTION
# What does this do?

It refactors the `fetch` function and the `Auth0API`'s `fetch_token` function so that the return value of  `fetch` has the type `{:ok | :error, any()}`.

# How does this change work?

On the `Auth0API` side we're using the `post` function without the `!`. This will have it return `{:error, %HTTPoison.Error{}}` if anything goes sour. Further, we're checking for Auth0 errors via the pattern matching.

Lastly, `fetch` was refactored to use `with` instead of `case`.