### PR TITLE
send content type headers when sending content

### DIFF
--- a/lib/pxu_auth0/plugs/api_authenticator.ex
+++ b/lib/pxu_auth0/plugs/api_authenticator.ex
@@ -13,6 +13,7 @@ defmodule PxUAuth0.Plugs.APIAuthenticator do
 
       _res ->
         conn
+        |> put_resp_header("content-type", "application/json")
         |> resp(401, "{\"Error\": \"Not Authorized\"}")
         |> halt()
     end

--- a/lib/pxu_auth0/plugs/requires_group.ex
+++ b/lib/pxu_auth0/plugs/requires_group.ex
@@ -12,6 +12,7 @@ defmodule PxUAuth0.Plugs.RequiresGroup do
     else
       _ ->
         conn
+        |> put_resp_header("content-type", "text/html")
         |> resp(401, "Not Authorized.")
         |> halt()
     end


### PR DESCRIPTION
without content type headers browsers get confused on what to do with the returned content